### PR TITLE
Add data tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# JetBrains IDE
+.idea/
+
+# Foundry locks
+*.lock
+

--- a/templates/character-sheet.html
+++ b/templates/character-sheet.html
@@ -111,6 +111,9 @@
             <a class="item" data-tab="cybernetics">{{localize 'OD6S.TAB_CYBERNETICS'}}</a>
         {{/if}}
         <a class="item" data-tab="description">{{localize 'OD6S.TAB_BIOGRAPHY'}}</a>
+        {{#if (eq data.sheetmode.value 'freeedit') }}
+        <a class="item" data-tab="data"><i class="fas fa-cog"></i></a>
+        {{/if}}
     </nav>
     {{!-- Sheet Body --}}
     <section class="sheet-body">
@@ -134,6 +137,11 @@
 
         {{!-- Biography Tab --}}
         {{> systems/od6s/templates/actor/character/tabs/biography.html}}
+
+        {{#if (eq data.sheetmode.value 'freeedit') }}
+        {{!-- Data Tab --}}
+            {{> systems/od6s/templates/actor/common/tabs/data.html}}
+        {{/if}}
     </section>
 </form>
 </div>

--- a/templates/character-sheet.html
+++ b/templates/character-sheet.html
@@ -1,147 +1,165 @@
 <div class=background-image>
-<form class="{{cssClass}} flexcol" autocomplete="off">
-    {{!-- Sheet Header --}}
-    <header class="sheet-header flex-group-left">
-        <div class="grid grid-2col">
-	    <img class="sw-logo" src="modules/od6s-star-wars/templates/logo.webp" width="150">
-            <h1 class="charname">
-                <input title="{{localize OD6S.CHAR_NAME}}" name="name" type="text" value="{{actor.name}}"
-                       placeholder="{{localize OD6S.CHAR_NAME}}" data-dtype="String"/>
-            </h1>
-                        <div><b><label for="data.chartype.content">{{localize data.chartype.label}}:</label></b>
-                        <input title="{{localize data.chartype.label}}" name="data.chartype.content" type="text"
-                               value="{{data.chartype.content}}" placeholder="{{localize data.chartype.label}}"
-                               data-dtype="{{data.chartype.type}}"/>
-                        {{#if (eq data.sheetmode.value "freeedit")}}
-                            <button class="reset-template">Clear</button>
-                        {{/if}}</div>
-                        <div><b><label for="data.species.content">{{localize data.species.label}}:</label></b>
-
-                        <input title="{{localize data.species.label}}" name="data.species.content" type="text"
-                               value="{{data.species.content}}" placeholder="{{localize data.species.label}}"
-                               data-dtype="{{data.species.type}}"/></div>
-	    <div class="grid grid-2col">
-            <div class="grid grid-4col header-fields">
-                <div class="flexrow flex-group-center">
-                    <b><label for="data.characterpoints.value">{{localize data.characterpoints.short_label}}:</label></b>
-                    <input title="{{localize data.characterpoints.label}}" name="data.characterpoints.value"
-                           type="number" min="0" max="99"
-                           value="{{data.characterpoints.value}}" placeholder="0"
-                           data-dtype="{{data.characterpoints.type}}"/>
-                </div>
-                <div class="flexrow flex-group-center">
-                    <b><label for="data.fatepoints.value">{{getFatePointsShortName}}:</label></b>
-                    <input title="{{getFatePointsShortName}}" name="data.fatepoints.value" type="number"
-                           min="0" max="99" value="{{data.fatepoints.value}}" placeholder="0"
-                           data-dtype="{{data.fatepoints.type}}"/>
-                    <div class="flexrow flex-group-left fatepointeffect"
-                         title="{{localize 'OD6S.IN_EFFECT'}}">
-                        <input type="checkbox"
-			       {{#unless (gt data.fatepoints.value 0)}}
-                                {{#unless actor.flags.od6s.fatepointeffect}}disabled{{/unless}}
-                            {{/unless}}
-                               data-dtype="Boolean" {{checked actor.data.flags.od6s.fatepointeffect}}>
+    <form class="{{cssClass}} flexcol" autocomplete="off">
+        {{!-- Sheet Header --}}
+        <header class="sheet-header flex-group-left">
+            <div class="grid grid-2col">
+                <img class="sw-logo" src="modules/od6s-star-wars/templates/logo.webp" width="150">
+                <h1 class="charname">
+                    <input title="{{localize OD6S.CHAR_NAME}}" name="name" type="text" value="{{actor.name}}"
+                           placeholder="{{localize OD6S.CHAR_NAME}}" data-dtype="String"/>
+                </h1>
+                    <div>
+                        <div
+                            {{#if (eq data.sheetmode.value "freeedit")}}
+                            class="grid grid-3col-type"
+                            {{else}}
+                            class="grid grid-2col-type"
+                            {{/if}}>
+                            <label for="data.chartype.content"><b>{{localize data.chartype.label}}:</b></label>
+                            <input title="{{localize data.chartype.label}}" name="data.chartype.content" type="text"
+                                   value="{{data.chartype.content}}" placeholder="{{localize data.chartype.label}}"
+                                   data-dtype="{{data.chartype.type}}"/>
+                            {{#if (eq data.sheetmode.value "freeedit")}}
+                                <button class="reset-template">Clear</button>
+                            {{/if}}
+                        </div>
                     </div>
-                </div>
-                {{#if (ne (getCustomField1) "")}}
-                    <div class="flexrow flex-group-center">
-                        <b><label for="data.custom1.value">{{getCustomField1Short}}:</label></b>
-                        <input title="{{getCustomField1Short}}" name="data.custom1.value" type="{{getCustomField1Type}}"
-                               value="{{data.custom1.value}}" data-dtype="{{getCustomField1FType}}"
-                            {{#if (eq (getCustomField1Type) "number") }}
-                               min="0" max="99" placeholder="0"
-                            {{/if}}/>
+                    <div>
+                        <div class="grid grid-2col-species">
+                            <label for="data.species.content"><b>{{localize data.species.label}}:</b></label>
+                            <input title="{{localize data.species.label}}" name="data.species.content" type="text"
+                                   value="{{data.species.content}}" placeholder="{{localize data.species.label}}"
+                                   data-dtype="{{data.species.type}}"/>
+                        </div>
                     </div>
-                {{/if}}
-                <div class="flexrow flex-group-center">
-                    <b><label for="data.metaphysicsextranormal.value">{{getMetaphysicsExtranormalName}}:</label></b>
-                    <input type="checkbox" name="data.metaphysicsextranormal.value"
-                           id="data.metaphysicsextranormal.value" data-dtype="Boolean"
-                        {{checked data.metaphysicsextranormal.value}}>
-                </div>
-                <div class="flexrow flex-group-center">
-                    <b><label for="data.move.value">{{localize data.move.label}}:</label></b>
-                    <input title="{{localize data.move.label}}" name="data.move.value" type="number" min="0" max="99"
-                           value="{{data.move.value}}" placeholder="10" data-dtype="{{data.move.type}}"/>
-                </div>
-                <div class="flexrow flex-group-center">
-                    <b><label for="data.credits.value">{{localize data.credits.label}}:</label></b>
-                    <input title="{{localize data.credits.label}}" name="data.credits.value" type="number" min="0"
-                           max="999999999999" value="{{data.credits.value}}" placeholder="{{data.credits.value}}"
-                           data-dtype="{{data.credits.type}}"/>
-                </div>
-                <div class="flexrow flex-group-left">
-                    <b><label for="data.wounds.value">{{localize 'OD6S.WOUNDS'}}:</label></b>
-                    <select name="data.wounds.value" id="data.wounds.value" style="width: 70px;">
-                        {{#select data.wounds.value}}
-                            {{#each (getWoundLevels 'character') as |level key|}}
-                                <option value="{{ key }}">
-                                    {{localize (woundsFromValue key 'character')}}
-                                </option>
-                            {{/each}}
-                        {{/select}}
-                    </select>
-                </div>
-                <div class="flexrow flex-group-left sheetmode">
-                    <b><label for="data.sheetmode.value">{{localize 'OD6S.SHEETMODE'}}:</label></b>
-                    <select name="data.sheetmode.value" id="data.sheetmode.value" style="width: 70px;">
-                        {{#select data.sheetmode.value}}
-                            <option value="normal">{{localize 'OD6S.SHEETMODE_NORMAL'}}</option>
-                            <option value="advance">{{localize 'OD6S.SHEETMODE_ADVANCE'}}</option>
-                            <option value="freeedit">{{localize 'OD6S.SHEETMODE_FREEDIT'}}</option>
-                        {{/select}}
-                    </select>
+                <div class="grid grid-2col">
+                    <div class="grid grid-4col header-fields">
+                        <div class="flexrow flex-group-center">
+                            <b><label for="data.characterpoints.value">{{localize data.characterpoints.short_label}}
+                                :</label></b>
+                            <input title="{{localize data.characterpoints.label}}" name="data.characterpoints.value"
+                                   type="number" min="0" max="99"
+                                   value="{{data.characterpoints.value}}" placeholder="0"
+                                   data-dtype="{{data.characterpoints.type}}"/>
+                        </div>
+                        <div class="flexrow flex-group-center">
+                            <b><label for="data.fatepoints.value">{{getFatePointsShortName}}:</label></b>
+                            <input title="{{getFatePointsShortName}}" name="data.fatepoints.value" type="number"
+                                   min="0" max="99" value="{{data.fatepoints.value}}" placeholder="0"
+                                   data-dtype="{{data.fatepoints.type}}"/>
+                            <div class="flexrow flex-group-left fatepointeffect"
+                                 title="{{localize 'OD6S.IN_EFFECT'}}">
+                                <input type="checkbox"
+                                    {{#unless (gt data.fatepoints.value 0)}}
+                                        {{#unless actor.flags.od6s.fatepointeffect}}disabled{{/unless}}
+                                    {{/unless}}
+                                       data-dtype="Boolean" {{checked actor.data.flags.od6s.fatepointeffect}}>
+                            </div>
+                        </div>
+                        {{#if (ne (getCustomField1) "")}}
+                            <div class="flexrow flex-group-center">
+                                <b><label for="data.custom1.value">{{getCustomField1Short}}:</label></b>
+                                <input title="{{getCustomField1Short}}" name="data.custom1.value"
+                                       type="{{getCustomField1Type}}"
+                                       value="{{data.custom1.value}}" data-dtype="{{getCustomField1FType}}"
+                                    {{#if (eq (getCustomField1Type) "number") }}
+                                       min="0" max="99" placeholder="0"
+                                    {{/if}}/>
+                            </div>
+                        {{/if}}
+                        <div class="flexrow flex-group-center">
+                            <b><label for="data.metaphysicsextranormal.value">{{getMetaphysicsExtranormalName}}:</label></b>
+                            <input type="checkbox" name="data.metaphysicsextranormal.value"
+                                   id="data.metaphysicsextranormal.value" data-dtype="Boolean"
+                                {{checked data.metaphysicsextranormal.value}}>
+                        </div>
+                        <div class="flexrow flex-group-center">
+                            <b><label for="data.move.value">{{localize data.move.label}}:</label></b>
+                            <input title="{{localize data.move.label}}" name="data.move.value" type="number" min="0"
+                                   max="99"
+                                   value="{{data.move.value}}" placeholder="10" data-dtype="{{data.move.type}}"/>
+                        </div>
+                        <div class="flexrow flex-group-center">
+                            <b><label for="data.credits.value">{{localize data.credits.label}}:</label></b>
+                            <input title="{{localize data.credits.label}}" name="data.credits.value" type="number"
+                                   min="0"
+                                   max="999999999999" value="{{data.credits.value}}"
+                                   placeholder="{{data.credits.value}}"
+                                   data-dtype="{{data.credits.type}}"/>
+                        </div>
+                        <div class="flexrow flex-group-left">
+                            <b><label for="data.wounds.value">{{localize 'OD6S.WOUNDS'}}:</label></b>
+                            <select name="data.wounds.value" id="data.wounds.value" style="width: 70px;">
+                                {{#select data.wounds.value}}
+                                    {{#each (getWoundLevels 'character') as |level key|}}
+                                        <option value="{{ key }}">
+                                            {{localize (woundsFromValue key 'character')}}
+                                        </option>
+                                    {{/each}}
+                                {{/select}}
+                            </select>
+                        </div>
+                        <div class="flexrow flex-group-left sheetmode">
+                            <b><label for="data.sheetmode.value">{{localize 'OD6S.SHEETMODE'}}:</label></b>
+                            <select name="data.sheetmode.value" id="data.sheetmode.value" style="width: 70px;">
+                                {{#select data.sheetmode.value}}
+                                    <option value="normal">{{localize 'OD6S.SHEETMODE_NORMAL'}}</option>
+                                    <option value="advance">{{localize 'OD6S.SHEETMODE_ADVANCE'}}</option>
+                                    <option value="freeedit">{{localize 'OD6S.SHEETMODE_FREEDIT'}}</option>
+                                {{/select}}
+                            </select>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-	</div>
-	<img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="200" width="200" alt="Actor Image"/>
-    </header>
+            <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="200" width="200"
+                 alt="Actor Image"/>
+        </header>
 
-    {{!-- Sheet Tab Navigation --}}
-    <nav class="sheet-tabs tabs" data-group="primary">
-        <a class="item" data-tab="attributes">{{localize 'OD6S.TAB_ATTRSKILLS'}}</a>
-        <a class="item" data-tab="combat">{{localize 'OD6S.TAB_COMBAT'}}</a>
-        {{#if data.metaphysicsextranormal.value}}
-            <a class="item" data-tab="metaphysics">{{getMetaphysicsName}}</a>
-        {{/if}}
-        <a class="item" data-tab="inventory">{{localize 'OD6S.TAB_INVENTORY'}}</a>
-        <a class="item" data-tab="special-abilities">{{localize 'OD6S.TAB_SPECIAL_ABILITIES'}}</a>
-        {{# if (hasCybernetics actor) }}
-            <a class="item" data-tab="cybernetics">{{localize 'OD6S.TAB_CYBERNETICS'}}</a>
-        {{/if}}
-        <a class="item" data-tab="description">{{localize 'OD6S.TAB_BIOGRAPHY'}}</a>
-        {{#if (eq data.sheetmode.value 'freeedit') }}
-        <a class="item" data-tab="data"><i class="fas fa-cog"></i></a>
-        {{/if}}
-    </nav>
-    {{!-- Sheet Body --}}
-    <section class="sheet-body">
-        {{!-- Attribues Tab --}}
-        {{> systems/od6s/templates/actor/character/tabs/attributes.html}}
+        {{!-- Sheet Tab Navigation --}}
+        <nav class="sheet-tabs tabs" data-group="primary">
+            <a class="item" data-tab="attributes">{{localize 'OD6S.TAB_ATTRSKILLS'}}</a>
+            <a class="item" data-tab="combat">{{localize 'OD6S.TAB_COMBAT'}}</a>
+            {{#if data.metaphysicsextranormal.value}}
+                <a class="item" data-tab="metaphysics">{{getMetaphysicsName}}</a>
+            {{/if}}
+            <a class="item" data-tab="inventory">{{localize 'OD6S.TAB_INVENTORY'}}</a>
+            <a class="item" data-tab="special-abilities">{{localize 'OD6S.TAB_SPECIAL_ABILITIES'}}</a>
+            {{# if (hasCybernetics actor) }}
+                <a class="item" data-tab="cybernetics">{{localize 'OD6S.TAB_CYBERNETICS'}}</a>
+            {{/if}}
+            <a class="item" data-tab="description">{{localize 'OD6S.TAB_BIOGRAPHY'}}</a>
+            {{#if (eq data.sheetmode.value 'freeedit') }}
+                <a class="item" data-tab="data"><i class="fas fa-cog"></i></a>
+            {{/if}}
+        </nav>
+        {{!-- Sheet Body --}}
+        <section class="sheet-body">
+            {{!-- Attribues Tab --}}
+            {{> systems/od6s/templates/actor/character/tabs/attributes.html}}
 
-        {{!-- Combat Tab --}}
-        {{> systems/od6s/templates/actor/common/tabs/combat.html}}
+            {{!-- Combat Tab --}}
+            {{> systems/od6s/templates/actor/common/tabs/combat.html}}
 
-        {{!-- Metaphysics Tab --}}{{#if data.metaphysicsextranormal.value}}
-        {{> systems/od6s/templates/actor/character/tabs/metaphysics.html}}{{/if}}
+            {{!-- Metaphysics Tab --}}{{#if data.metaphysicsextranormal.value}}
+            {{> systems/od6s/templates/actor/character/tabs/metaphysics.html}}{{/if}}
 
-        {{!-- Inventory Tab --}}
-        {{> systems/od6s/templates/actor/character/tabs/inventory.html}}
+            {{!-- Inventory Tab --}}
+            {{> systems/od6s/templates/actor/character/tabs/inventory.html}}
 
-        {{!-- Owned Special Abilities Tab --}}
-        {{> systems/od6s/templates/actor/common/tabs/special-abilities.html}}
+            {{!-- Owned Special Abilities Tab --}}
+            {{> systems/od6s/templates/actor/common/tabs/special-abilities.html}}
 
-        {{!-- Owned Cybernetics Tab --}}
-        {{>systems/od6s/templates/actor/common/tabs/cybernetics.html}}
+            {{!-- Owned Cybernetics Tab --}}
+            {{>systems/od6s/templates/actor/common/tabs/cybernetics.html}}
 
-        {{!-- Biography Tab --}}
-        {{> systems/od6s/templates/actor/character/tabs/biography.html}}
+            {{!-- Biography Tab --}}
+            {{> systems/od6s/templates/actor/character/tabs/biography.html}}
 
-        {{#if (eq data.sheetmode.value 'freeedit') }}
-        {{!-- Data Tab --}}
-            {{> systems/od6s/templates/actor/common/tabs/data.html}}
-        {{/if}}
-    </section>
-</form>
+            {{#if (eq data.sheetmode.value 'freeedit') }}
+            {{!-- Data Tab --}}
+                {{> systems/od6s/templates/actor/common/tabs/data.html}}
+            {{/if}}
+        </section>
+    </form>
 </div>

--- a/templates/creature-sheet.html
+++ b/templates/creature-sheet.html
@@ -49,6 +49,9 @@
     <nav class="sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="main">{{localize 'OD6S.MAIN'}}</a>
         <a class="item" data-tab="combat">{{localize 'OD6S.TAB_COMBAT'}}</a>
+        {{#if (eq data.sheetmode.value 'freeedit') }}
+            <a class="item" data-tab="data"><i class="fas fa-cog"></i></a>
+        {{/if}}
     </nav>
     {{!-- Sheet Body --}}
     <section class="sheet-body">
@@ -57,5 +60,10 @@
 
         {{!-- Combat Tab --}}
         {{> systems/od6s/templates/actor/common/tabs/combat.html}}
+
+        {{#if (eq data.sheetmode.value 'freeedit') }}
+        {{!-- Data Tab --}}
+        {{> systems/od6s/templates/actor/common/tabs/data.html}}
+        {{/if}}
     </section>
 </form>

--- a/templates/npc-sheet.html
+++ b/templates/npc-sheet.html
@@ -56,6 +56,9 @@
     <nav class="sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="main">{{localize 'OD6S.MAIN'}}</a>
         <a class="item" data-tab="combat">{{localize 'OD6S.TAB_COMBAT'}}</a>
+        {{#if (eq data.sheetmode.value 'freeedit') }}
+            <a class="item" data-tab="data"><i class="fas fa-cog"></i></a>
+        {{/if}}
     </nav>
     {{!-- Sheet Body --}}
     <section class="sheet-body">
@@ -64,6 +67,11 @@
 
         {{!-- Combat Tab --}}
         {{> systems/od6s/templates/actor/common/tabs/combat.html}}
+
+        {{#if (eq data.sheetmode.value 'freeedit') }}
+        {{!-- Data Tab --}}
+            {{> systems/od6s/templates/actor/common/tabs/data.html}}
+        {{/if}}
     </section>
 </form>
 


### PR DESCRIPTION
Lines up the type/species field.
Makes the "Clear Template" button smaller and in-line.
Adds a "Data" tab to the actor sheets (character/creature/npc) which allows you to see/edit all scores and items.