### PR TITLE
Update module.json for v10

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,11 +2,31 @@
   "name": "od6s-star-wars",
   "title": "Star Wars Sheets for OpenD6",
   "description": "Star Wars Sheets for OpenD6 in FoundryVTT!",
-  "version": "0.0.21",
-  "minimumCoreVersion": "0.8.6",
-  "compatibleCoreVersion": "9.299",
-  "author": "Christian Ovsenik",
-  "system": ["od6s"],
+  "version": "1.0.0",
+  "authors": [
+    {
+      "name": "Christian Ovsenik"
+    }
+  ],
+  "compatibility": {
+      "minimum": "10",
+      "verified": "10.291",
+      "maximum": "10"
+  },
+    "relationships": {
+    "systems": [
+      {
+        "id": "od6s",
+        "type": "system",
+        "compatibility": [
+          {
+            "minimum": "0.7.10",
+            "verified": "0.7.10"
+          }
+        ]
+      }
+    ]
+  },
   "esmodules": [
 	"module/od6s-star-wars.js"
 	],


### PR DESCRIPTION
Updates module.json for FoundryVTT v10 and bumps version to 1.0.0 (since it'll break backwards compatibility with older Foundry versions)